### PR TITLE
Fix situation where processor is going too quickly.

### DIFF
--- a/ts4231.cpp
+++ b/ts4231.cpp
@@ -39,6 +39,7 @@ uint8_t TS4231::ts_digitalRead(int pin) {
 
 void TS4231::ts_digitalWrite(int pin, uint8_t write_val) {
   digitalWrite(pin, write_val);
+  delayMicroseconds(1); //If digitalWrite takes less than 50ns, it can cause issues with mode selection.
   }
 
 unsigned long TS4231::ts_millis() {


### PR DESCRIPTION
If you run this code on a processor which executes `ts_digitalWrite` too quickly, the TS4231 will almost always fail to enter WATCH mode safely.